### PR TITLE
feat: add azure postgres config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-OPENAI_API_KEY=
-PGUSER=
-PGPASSWORD=
-PGHOST=localhost
+OPENAI_API_KEY=sk-...
+PGUSER=genai_admin
+PGPASSWORD=...
+PGHOST=pdbsndevbnw.postgres.database.azure.com
 PGPORT=5432
-PGDATABASE=world_cities
+PGDATABASE=abs_data

--- a/src/app/api/data/route.ts
+++ b/src/app/api/data/route.ts
@@ -6,6 +6,12 @@ type SqlRow = Record<string, SqlValue>;
 type SqlQueryResult = SqlRow[];
 
 const pool = new Pool({
+  host: process.env.PGHOST,
+  port: process.env.PGPORT ? parseInt(process.env.PGPORT) : undefined,
+  user: process.env.PGUSER,
+  password: process.env.PGPASSWORD,
+  database: process.env.PGDATABASE,
+  ssl: { rejectUnauthorized: false },
   max: 20,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000,

--- a/src/lib/seed.ts
+++ b/src/lib/seed.ts
@@ -143,7 +143,14 @@ function escapeSql(str: string): string {
 }
 
 async function seed(): Promise<void> {
-  const client = new Client();
+  const client = new Client({
+    host: process.env.PGHOST,
+    port: process.env.PGPORT ? parseInt(process.env.PGPORT) : undefined,
+    user: process.env.PGUSER,
+    password: process.env.PGPASSWORD,
+    database: process.env.PGDATABASE,
+    ssl: { rejectUnauthorized: false },
+  });
 
   try {
     await client.connect();

--- a/src/mastra/tools/population-info.ts
+++ b/src/mastra/tools/population-info.ts
@@ -3,6 +3,12 @@ import { z } from "zod";
 import { Pool } from "pg";
 
 const pool = new Pool({
+  host: process.env.PGHOST,
+  port: process.env.PGPORT ? parseInt(process.env.PGPORT) : undefined,
+  user: process.env.PGUSER,
+  password: process.env.PGPASSWORD,
+  database: process.env.PGDATABASE,
+  ssl: { rejectUnauthorized: false },
   max: 20,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 20000,


### PR DESCRIPTION
## Summary
- configure postgres pool and client to use env variables
- add SSL settings for Azure Postgres
- update env example with connection values

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font file from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fd300b988330b67cf9c9953857ab