### PR TITLE
feat: style UI with Bank Now theme

### DIFF
--- a/src/app/data/page.tsx
+++ b/src/app/data/page.tsx
@@ -54,20 +54,20 @@ export default function DataPage() {
   };
 
   return (
-    <div className="min-h-screen bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-100">
+    <div className="min-h-screen bg-background text-foreground">
       {/* Header with subtle border */}
-      <header className="relative py-8 mb-8 border-b border-gray-200 dark:border-gray-800">
+      <header className="relative py-8 mb-8 border-b border-border">
         <div className="container mx-auto px-4 relative z-10">
-          <h1 className="text-4xl md:text-5xl font-bold text-center text-gray-800 dark:text-white">
+          <h1 className="text-4xl md:text-5xl font-bold text-center text-primary">
             City Population Database
           </h1>
-          <p className="text-center text-gray-600 dark:text-gray-300 mt-2 max-w-2xl mx-auto">
+          <p className="text-center text-muted-foreground mt-2 max-w-2xl mx-auto">
             Complete database of city population information
           </p>
           <div className="mt-6 text-center">
             <Link
               href="/"
-              className="text-blue-600 dark:text-blue-400 hover:underline"
+              className="text-primary hover:underline"
             >
               ← Back to Chat
             </Link>
@@ -77,19 +77,19 @@ export default function DataPage() {
 
       <main className="container mx-auto px-4 max-w-7xl pb-16">
         <section>
-          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden border border-gray-200 dark:border-gray-700">
+          <div className="bg-card rounded-lg shadow-md overflow-hidden border border-border">
             {isLoading ? (
               <div className="p-12 text-center">
-                <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-blue-600 border-r-transparent dark:border-blue-400 align-[-0.125em] motion-reduce:animate-[spin_1.5s_linear_infinite]"></div>
-                <p className="mt-4 text-gray-600 dark:text-gray-300">
+                <div className="inline-block h-8 w-8 animate-spin rounded-full border-4 border-solid border-primary border-r-transparent align-[-0.125em] motion-reduce:animate-[spin_1.5s_linear_infinite]"></div>
+                <p className="mt-4 text-muted-foreground">
                   Loading database...
                 </p>
               </div>
             ) : error ? (
               <div className="p-6 text-center">
-                <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-100 dark:bg-red-900 mb-4">
+                <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-destructive/10 mb-4">
                   <svg
-                    className="w-8 h-8 text-red-600 dark:text-red-400"
+                    className="w-8 h-8 text-destructive"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -103,45 +103,45 @@ export default function DataPage() {
                     />
                   </svg>
                 </div>
-                <h3 className="text-lg font-medium text-red-800 dark:text-red-300 mb-2">
+                <h3 className="text-lg font-medium text-destructive mb-2">
                   Error
                 </h3>
-                <p className="text-gray-600 dark:text-gray-300">{error}</p>
+                <p className="text-muted-foreground">{error}</p>
               </div>
             ) : tableData && tableData.headers.length > 0 ? (
               <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <table className="min-w-full divide-y divide-border">
                   <thead>
-                    <tr className="bg-gray-100 dark:bg-gray-800">
+                    <tr className="bg-muted">
                       {tableData.headers.map((header, index) => (
                         <th
                           key={index}
                           scope="col"
-                          className="px-6 py-3 text-left text-xs font-medium text-gray-600 dark:text-gray-300 uppercase tracking-wider"
+                          className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider"
                         >
                           {formatHeaderName(header)}
                         </th>
                       ))}
                     </tr>
                   </thead>
-                  <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                  <tbody className="bg-card divide-y divide-border">
                     {tableData.rows.map((row, rowIndex) => (
                       <tr
                         key={rowIndex}
                         className={
                           rowIndex % 2 === 0
-                            ? "bg-white dark:bg-gray-800"
-                            : "bg-gray-50 dark:bg-gray-700"
+                            ? "bg-card"
+                            : "bg-muted"
                         }
                       >
                         {row.map((cell, cellIndex) => (
                           <td
                             key={cellIndex}
-                            className="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300"
+                            className="px-6 py-4 whitespace-nowrap text-sm text-foreground"
                           >
                             {!isNaN(Number(cell.replace(/,/g, ""))) ? (
                               <span
-                                className={`font-medium ${cellIndex === 1 ? "text-blue-600 dark:text-blue-400" : "text-gray-800 dark:text-gray-200"}`}
+                                className={`font-medium ${cellIndex === 1 ? "text-primary" : "text-foreground"}`}
                               >
                                 {formatNumber(cell)}
                               </span>
@@ -157,7 +157,7 @@ export default function DataPage() {
               </div>
             ) : (
               <div className="p-6 text-center">
-                <p className="text-gray-600 dark:text-gray-300">
+                <p className="text-muted-foreground">
                   No data available
                 </p>
               </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,10 +83,73 @@
   --radius-xl: calc(var(--radius) + 4px);
 }
 
-:root { --radius: 0.625rem; --background: oklch(1 0 0); --foreground: oklch(0.145 0 0); --card: oklch(1 0 0); --card-foreground: oklch(0.145 0 0); --popover: oklch(1 0 0); --popover-foreground: oklch(0.145 0 0); --primary: oklch(0.205 0 0); --primary-foreground: oklch(0.985 0 0); --secondary: oklch(0.97 0 0); --secondary-foreground: oklch(0.205 0 0); --muted: oklch(0.97 0 0); --muted-foreground: oklch(0.556 0 0); --accent: oklch(0.97 0 0); --accent-foreground: oklch(0.205 0 0); --destructive: oklch(0.577 0.245 27.325); --border: oklch(0.922 0 0); --input: oklch(0.922 0 0); --ring: oklch(0.708 0 0); --chart-1: oklch(0.646 0.222 41.116); --chart-2: oklch(0.6 0.118 184.704); --chart-3: oklch(0.398 0.07 227.392); --chart-4: oklch(0.828 0.189 84.429); --chart-5: oklch(0.769 0.188 70.08); --sidebar: oklch(0.985 0 0); --sidebar-foreground: oklch(0.145 0 0); --sidebar-primary: oklch(0.205 0 0); --sidebar-primary-foreground: oklch(0.985 0 0); --sidebar-accent: oklch(0.97 0 0); --sidebar-accent-foreground: oklch(0.205 0 0); --sidebar-border: oklch(0.922 0 0); --sidebar-ring: oklch(0.708 0 0);
+:root {
+  --radius: 0.625rem;
+  --background: #ffffff;
+  --foreground: #1a1a1a;
+  --card: #ffffff;
+  --card-foreground: #1a1a1a;
+  --popover: #ffffff;
+  --popover-foreground: #1a1a1a;
+  --primary: #e30613;
+  --primary-foreground: #ffffff;
+  --secondary: #005ea5;
+  --secondary-foreground: #ffffff;
+  --muted: #f5f5f5;
+  --muted-foreground: #6b7280;
+  --accent: #f5f5f5;
+  --accent-foreground: #1a1a1a;
+  --destructive: #991b1b;
+  --border: #e5e7eb;
+  --input: #e5e7eb;
+  --ring: #e30613;
+  --chart-1: #e30613;
+  --chart-2: #005ea5;
+  --chart-3: #f59e0b;
+  --chart-4: #16a34a;
+  --chart-5: #9333ea;
+  --sidebar: #ffffff;
+  --sidebar-foreground: #1a1a1a;
+  --sidebar-primary: #e30613;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #f5f5f5;
+  --sidebar-accent-foreground: #1a1a1a;
+  --sidebar-border: #e5e7eb;
+  --sidebar-ring: #e30613;
 }
 
-.dark { --background: oklch(0.145 0 0); --foreground: oklch(0.985 0 0); --card: oklch(0.205 0 0); --card-foreground: oklch(0.985 0 0); --popover: oklch(0.205 0 0); --popover-foreground: oklch(0.985 0 0); --primary: oklch(0.922 0 0); --primary-foreground: oklch(0.205 0 0); --secondary: oklch(0.269 0 0); --secondary-foreground: oklch(0.985 0 0); --muted: oklch(0.269 0 0); --muted-foreground: oklch(0.708 0 0); --accent: oklch(0.269 0 0); --accent-foreground: oklch(0.985 0 0); --destructive: oklch(0.704 0.191 22.216); --border: oklch(1 0 0 / 10%); --input: oklch(1 0 0 / 15%); --ring: oklch(0.556 0 0); --chart-1: oklch(0.488 0.243 264.376); --chart-2: oklch(0.696 0.17 162.48); --chart-3: oklch(0.769 0.188 70.08); --chart-4: oklch(0.627 0.265 303.9); --chart-5: oklch(0.645 0.246 16.439); --sidebar: oklch(0.205 0 0); --sidebar-foreground: oklch(0.985 0 0); --sidebar-primary: oklch(0.488 0.243 264.376); --sidebar-primary-foreground: oklch(0.985 0 0); --sidebar-accent: oklch(0.269 0 0); --sidebar-accent-foreground: oklch(0.985 0 0); --sidebar-border: oklch(1 0 0 / 10%); --sidebar-ring: oklch(0.556 0 0);
+.dark {
+  --background: #1a1a1a;
+  --foreground: #ffffff;
+  --card: #272727;
+  --card-foreground: #ffffff;
+  --popover: #272727;
+  --popover-foreground: #ffffff;
+  --primary: #e30613;
+  --primary-foreground: #ffffff;
+  --secondary: #005ea5;
+  --secondary-foreground: #ffffff;
+  --muted: #333333;
+  --muted-foreground: #9ca3af;
+  --accent: #333333;
+  --accent-foreground: #ffffff;
+  --destructive: #f87171;
+  --border: #333333;
+  --input: #333333;
+  --ring: #e30613;
+  --chart-1: #e30613;
+  --chart-2: #005ea5;
+  --chart-3: #fbbf24;
+  --chart-4: #4ade80;
+  --chart-5: #a855f7;
+  --sidebar: #272727;
+  --sidebar-foreground: #ffffff;
+  --sidebar-primary: #e30613;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #333333;
+  --sidebar-accent-foreground: #ffffff;
+  --sidebar-border: #333333;
+  --sidebar-ring: #e30613;
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Open_Sans, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
+const openSans = Open_Sans({
   variable: "--font-geist-sans",
   subsets: ["latin"],
+  weight: ["400","700"],
 });
 
 const geistMono = Geist_Mono({
@@ -25,7 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning={true}>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${openSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,14 +4,14 @@ import Link from "next/link";
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center text-wrap">
-      <header className="w-full py-4 px-6 mb-8 flex fixed top-0 z-50 justify-center items-center bg-gray-100 dark:bg-gray-800 shadow-sm">
+      <header className="w-full py-4 px-6 mb-8 flex fixed top-0 z-50 justify-center items-center bg-primary text-primary-foreground shadow-sm">
         <div className="w-full max-w-5xl flex justify-between items-center">
-          <h1 className="text-2xl font-semibold text-gray-800">
+          <h1 className="text-2xl font-semibold">
             Mastra Text-to-SQL Demo: World Cities Population
           </h1>
           <Link
             href="/data"
-            className="px-4 py-2 text-sm bg-gray-500 hover:bg-gray-600 text-white rounded-md transition-colors"
+            className="px-4 py-2 text-sm bg-secondary hover:bg-secondary/90 text-secondary-foreground rounded-md transition-colors"
           >
             View Dataset
           </Link>


### PR DESCRIPTION
## Summary
- adopt Bank Now inspired colors and typography
- theme dataset and chat pages with brand variables

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1063af6f48330bd1db444183e71b7