### PR TITLE
feat: apply bank-themed colors

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -91,10 +91,10 @@
   --card-foreground: #1a1a1a;
   --popover: #ffffff;
   --popover-foreground: #1a1a1a;
-  --primary: #10a37f;
+  --primary: #7f00ff;
   --primary-foreground: #ffffff;
-  --secondary: #3f3f46;
-  --secondary-foreground: #ffffff;
+  --secondary: #facc15;
+  --secondary-foreground: #1a1a1a;
   --muted: #ececec;
   --muted-foreground: #6b7280;
   --accent: #ececec;
@@ -102,20 +102,20 @@
   --destructive: #991b1b;
   --border: #e5e7eb;
   --input: #e5e7eb;
-  --ring: #10a37f;
-  --chart-1: #10a37f;
-  --chart-2: #3f3f46;
+  --ring: #7f00ff;
+  --chart-1: #7f00ff;
+  --chart-2: #facc15;
   --chart-3: #f59e0b;
   --chart-4: #16a34a;
   --chart-5: #9333ea;
   --sidebar: #f7f7f8;
   --sidebar-foreground: #1a1a1a;
-  --sidebar-primary: #10a37f;
+  --sidebar-primary: #7f00ff;
   --sidebar-primary-foreground: #ffffff;
   --sidebar-accent: #ececec;
   --sidebar-accent-foreground: #1a1a1a;
   --sidebar-border: #e5e7eb;
-  --sidebar-ring: #10a37f;
+  --sidebar-ring: #7f00ff;
 }
 
 .dark {
@@ -125,10 +125,10 @@
   --card-foreground: #ffffff;
   --popover: #444654;
   --popover-foreground: #ffffff;
-  --primary: #10a37f;
+  --primary: #c084fc;
   --primary-foreground: #ffffff;
-  --secondary: #565869;
-  --secondary-foreground: #ffffff;
+  --secondary: #facc15;
+  --secondary-foreground: #1a1a1a;
   --muted: #444654;
   --muted-foreground: #d1d5db;
   --accent: #444654;
@@ -136,20 +136,20 @@
   --destructive: #f87171;
   --border: #565869;
   --input: #565869;
-  --ring: #10a37f;
-  --chart-1: #10a37f;
-  --chart-2: #565869;
+  --ring: #c084fc;
+  --chart-1: #c084fc;
+  --chart-2: #facc15;
   --chart-3: #fbbf24;
   --chart-4: #4ade80;
   --chart-5: #a855f7;
   --sidebar: #343541;
   --sidebar-foreground: #ffffff;
-  --sidebar-primary: #10a37f;
+  --sidebar-primary: #c084fc;
   --sidebar-primary-foreground: #ffffff;
   --sidebar-accent: #444654;
   --sidebar-accent-foreground: #ffffff;
   --sidebar-border: #565869;
-  --sidebar-ring: #10a37f;
+  --sidebar-ring: #c084fc;
 }
 
 @layer base {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,14 +4,14 @@ import Link from "next/link";
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center bg-background text-wrap">
-      <header className="w-full py-4 px-6 mb-8 flex fixed top-0 z-50 justify-center items-center bg-background border-b shadow-sm">
+      <header className="w-full py-4 px-6 mb-8 flex fixed top-0 z-50 justify-center items-center bg-gradient-to-r from-purple-900 via-fuchsia-700 to-pink-600 text-white shadow-sm">
         <div className="w-full max-w-5xl flex justify-between items-center">
-          <h1 className="text-2xl font-semibold text-foreground">
+          <h1 className="text-2xl font-semibold">
             Chat with ABS Data
           </h1>
           <Link
             href="/data"
-            className="px-4 py-2 text-sm bg-primary hover:bg-primary/90 text-primary-foreground rounded-md transition-colors"
+            className="px-4 py-2 text-sm bg-secondary hover:bg-secondary/90 text-secondary-foreground rounded-md transition-colors"
           >
             View Dataset
           </Link>


### PR DESCRIPTION
## Summary
- apply purple primary and yellow secondary color palette
- update header with gradient and button with secondary styling

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a11d68c72c83308c096010a5fc8b3e