### PR TITLE
feat: add Bank Now logo to chat header

### DIFF
--- a/public/bank-now-logo.svg
+++ b/public/bank-now-logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <circle cx="64" cy="64" r="64" fill="#8a2db0" />
+  <polygon points="96,128 128,128 128,96" fill="#8a2db0" />
+  <text x="64" y="54" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" font-size="28" fill="#ffffff">BANK</text>
+  <text x="64" y="94" text-anchor="middle" font-family="Arial, sans-serif" font-weight="bold" font-size="28" fill="#ffeb3b">now</text>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,21 @@
 import { Assistant } from "./assistant";
 import Link from "next/link";
+import Image from "next/image";
 
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center bg-background text-wrap">
       <header className="w-full py-4 px-6 mb-8 flex fixed top-0 z-50 justify-center items-center bg-gradient-to-r from-purple-900 via-fuchsia-700 to-pink-600 text-white shadow-sm">
         <div className="w-full max-w-5xl flex justify-between items-center">
-          <h1 className="text-2xl font-semibold">
-            Chat with ABS Data
-          </h1>
+          <div className="flex items-center gap-2">
+            <Image
+              src="/bank-now-logo.svg"
+              alt="Bank Now logo"
+              width={40}
+              height={40}
+            />
+            <h1 className="text-2xl font-semibold">Chat with ABS Data</h1>
+          </div>
           <Link
             href="/data"
             className="px-4 py-2 text-sm bg-secondary hover:bg-secondary/90 text-secondary-foreground rounded-md transition-colors"


### PR DESCRIPTION
## Summary
- add Bank Now logo asset
- display logo in chat UI header

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a11f791874833092e7eedc216cb7c6