### PR TITLE
Add collapsible thread sidebar

### DIFF
--- a/src/app/assistant.tsx
+++ b/src/app/assistant.tsx
@@ -1,12 +1,44 @@
 "use client";
 
+import { useState } from "react";
 import { MastraRuntimeProvider } from "@/app/MastraRuntimeProvider";
 import { Thread } from "@/components/assistant-ui/thread";
+import { ThreadList } from "@/components/assistant-ui/thread-list";
+import { cn } from "@/lib/utils";
+import {
+  PanelLeftCloseIcon,
+  PanelLeftOpenIcon,
+} from "lucide-react";
 
 export const Assistant = () => {
+  const [open, setOpen] = useState(false);
+
   return (
     <MastraRuntimeProvider>
-      <Thread />
+      <div className="flex h-full">
+        <aside
+          className={cn(
+            "border-r bg-muted transition-all duration-300 overflow-hidden h-[calc(100dvh-5rem)]",
+            open ? "mt-20 w-64 p-4" : "w-0 p-0",
+          )}
+        >
+          {open && <ThreadList />}
+        </aside>
+        <div className="relative flex-1">
+          <button
+            onClick={() => setOpen((o) => !o)}
+            className="absolute left-0 top-20 z-50 rounded-md border p-1 bg-background hover:bg-muted"
+            aria-label={open ? "Close thread list" : "Open thread list"}
+          >
+            {open ? (
+              <PanelLeftCloseIcon className="h-4 w-4" />
+            ) : (
+              <PanelLeftOpenIcon className="h-4 w-4" />
+            )}
+          </button>
+          <Thread />
+        </div>
+      </div>
     </MastraRuntimeProvider>
   );
 };

--- a/src/app/data/page.tsx
+++ b/src/app/data/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import BarChart from "@/components/bar-chart";
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,7 @@ export default function Home() {
           </Link>
         </div>
       </header>
-      <div className="w-full h-dvh px-6">
+      <div className="w-full h-dvh">
         <Assistant />
       </div>
     </main>


### PR DESCRIPTION
## Summary
- keep chat view fixed while positioning thread sidebar below the header
- align sidebar toggle with the left edge when collapsed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a12f75acb88330b9ca8ee4d7b8ecdc