### PR TITLE
feat: add Dockerfile for azure deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log*
+Dockerfile
+.dockerignore
+.git
+.gitignore
+.next
+.env
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Multi-stage Dockerfile for building and running the Next.js application
+
+# Install dependencies only when needed
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+# Rebuild the source code and remove dev dependencies
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build && npm prune --production
+
+# Production image
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=8080
+
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+
+EXPOSE 8080
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile to build and run the Next.js app on Azure App Service
- exclude unnecessary files from container builds with `.dockerignore`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1382415808330bc3ecd069f9aaa9b