### PR TITLE
Remove Google font dependency for offline builds

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -52,9 +52,15 @@ export async function POST(request: Request) {
             }
           } else if (part.type === "error") {
             try {
+              const errorMessage =
+                part.error &&
+                typeof part.error === "object" &&
+                "message" in part.error
+                  ? (part.error as { message: string }).message
+                  : "Unknown error";
               await writer.write(
                 encoder.encode(
-                  `data: ${JSON.stringify({ type: "error", value: part.error?.message || "Unknown error" })}\n\n`
+                  `data: ${JSON.stringify({ type: "error", value: errorMessage })}\n\n`
                 )
               );
             } catch (writeError) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -84,6 +84,9 @@
 }
 
 :root {
+  /* Fallback system fonts to avoid network fetches during build */
+  --font-geist-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --font-geist-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   --radius: 0.625rem;
   --background: #f7f7f8;
   --foreground: #1a1a1a;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,5 @@
 import type { Metadata } from "next";
-import { Open_Sans, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const openSans = Open_Sans({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-  weight: ["400","700"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Mastra Text to SQL",
@@ -25,11 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning={true}>
-      <body
-        className={`${openSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
-      </body>
+      <body className="antialiased">{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- avoid fetching Google Fonts at build time by dropping `next/font/google`
- provide system font fallbacks in global CSS
- guard error streaming to handle unknown error shapes

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a13ce191248330aa52ed1c81be45de