### PR TITLE
Add user initials avatar to header

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { Assistant } from "./assistant";
 import Link from "next/link";
 import Image from "next/image";
+import { UserAvatar } from "../components/user-avatar";
 
 export default function Home() {
   return (
@@ -15,12 +16,15 @@ export default function Home() {
           />
           <h1 className="text-2xl font-semibold">Chat with ABS Data</h1>
         </div>
-        <Link
-          href="/data"
-          className="px-4 py-2 text-sm bg-secondary hover:bg-secondary/90 text-secondary-foreground rounded-md transition-colors"
-        >
-          View Dataset
-        </Link>
+        <div className="flex items-center gap-4">
+          <Link
+            href="/data"
+            className="px-4 py-2 text-sm bg-secondary hover:bg-secondary/90 text-secondary-foreground rounded-md transition-colors"
+          >
+            View Dataset
+          </Link>
+          <UserAvatar />
+        </div>
       </header>
       <div className="w-full h-dvh">
         <Assistant />

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function UserAvatar() {
+  const [initials, setInitials] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchUser() {
+      try {
+        const res = await fetch("/.auth/me");
+        if (!res.ok) return;
+        const data = await res.json();
+        const userDetails =
+          data?.clientPrincipal?.userDetails || data?.userDetails || "";
+        if (userDetails) {
+          const parts = userDetails
+            .split(/[\s@._-]+/)
+            .filter(Boolean)
+            .slice(0, 2);
+          const init = parts.map((p) => p[0]?.toUpperCase()).join("");
+          setInitials(init || null);
+        }
+      } catch {
+        // ignore errors
+      }
+    }
+    fetchUser();
+  }, []);
+
+  if (!initials) return null;
+
+  return (
+    <div className="w-8 h-8 rounded-full bg-white text-purple-700 flex items-center justify-center text-sm font-medium">
+      {initials}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add user avatar component that fetches user info from `/.auth/me` and shows initials
- display user avatar in the header

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a19920ed0c8330a6ea128e85bcda83