### PR TITLE
feat: add anonymous avatar placeholder

### DIFF
--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -3,34 +3,38 @@
 import { useEffect, useState } from "react";
 
 export function UserAvatar() {
-  const [initials, setInitials] = useState<string | null>(null);
+  const [initials, setInitials] = useState<string>("A");
+  const [checked, setChecked] = useState(false);
 
   useEffect(() => {
     async function fetchUser() {
       try {
         const res = await fetch("/.auth/me");
-        if (!res.ok) return;
-        const data = await res.json();
-        const userDetails =
-          data?.clientPrincipal?.userDetails || data?.userDetails || "";
-        if (userDetails) {
-          const parts = userDetails
-            .split(/[\s@._-]+/)
-            .filter(Boolean)
-            .slice(0, 2);
-          const init = parts
-            .map((p: string) => p[0]?.toUpperCase())
-            .join("");
-          setInitials(init || null);
+        if (res.ok) {
+          const data = await res.json();
+          const userDetails =
+            data?.clientPrincipal?.userDetails || data?.userDetails || "";
+          if (userDetails) {
+            const parts = userDetails
+              .split(/[\s@._-]+/)
+              .filter(Boolean)
+              .slice(0, 2);
+            const init = parts
+              .map((p: string) => p[0]?.toUpperCase())
+              .join("");
+            setInitials(init || "A");
+          }
         }
       } catch {
         // ignore errors
+      } finally {
+        setChecked(true);
       }
     }
     fetchUser();
   }, []);
 
-  if (!initials) return null;
+  if (!checked) return null;
 
   return (
     <div className="w-8 h-8 rounded-full bg-white text-purple-700 flex items-center justify-center text-sm font-medium">


### PR DESCRIPTION
## Summary
- show placeholder "A" initials when user info fetch fails

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1a371be54833086aa5b5b4c66e55f