### PR TITLE
feat: add user avatar to user messages

### DIFF
--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -28,6 +28,7 @@ import { Button } from "@/components/ui/button";
 import { MarkdownText } from "@/components/assistant-ui/markdown-text";
 import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button";
 import BarChart from "@/components/bar-chart";
+import { useUserInitials } from "@/components/user-avatar";
 
 export const Thread: FC = () => {
   return (
@@ -257,12 +258,18 @@ const ComposerAction: FC = () => {
 };
 
 const UserMessage: FC = () => {
+  const { initials } = useUserInitials();
+
   return (
-    <MessagePrimitive.Root className="grid auto-rows-auto grid-cols-[minmax(72px,1fr)_auto] gap-y-2 [&:where(>*)]:col-start-2 w-full max-w-[var(--thread-max-width)] py-4">
+    <MessagePrimitive.Root className="grid auto-rows-auto grid-cols-[minmax(72px,1fr)_auto_auto] gap-y-2 [&:where(>*)]:col-start-2 w-full max-w-[var(--thread-max-width)] py-4">
       <UserActionBar />
 
       <div className="bg-background border text-foreground max-w-[calc(var(--thread-max-width)*0.8)] break-words rounded-3xl px-5 py-2.5 col-start-2 row-start-2">
         <MessagePrimitive.Content />
+      </div>
+
+      <div className="col-start-3 row-start-1 row-span-2 ml-3 flex h-10 w-10 items-center justify-center rounded-full bg-white text-purple-700 text-sm font-medium">
+        {initials}
       </div>
 
       <BranchPicker className="col-span-full col-start-1 row-start-3 -mr-1 justify-end" />


### PR DESCRIPTION
## Summary
- cache user details with a new `useUserInitials` hook
- show a user initials avatar in each user message bubble

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a1a9be50c8833097f1fee525048c8d