### PR TITLE
feat: name threads using azure

### DIFF
--- a/src/app/api/thread-name/route.ts
+++ b/src/app/api/thread-name/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { azure } from "@ai-sdk/azure";
+import { generateText } from "ai";
+
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+export async function POST(request: Request) {
+  const { messages } = await request.json();
+
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return NextResponse.json(
+      { error: "No messages provided" },
+      { status: 400 },
+    );
+  }
+
+  const model = azure(process.env.AZURE_DEPLOYMENT_NAME || "gpt-4o");
+  const prompt = `Create a short descriptive title for a conversation based on the following messages:\n${messages.join("\n")}`;
+
+  try {
+    const { text } = await generateText({ model, prompt });
+    return NextResponse.json({ title: text.trim() });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- name threads via Azure OpenAI API after thread creation
- expose `/api/thread-name` endpoint to generate concise thread titles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1b103e730833090337e234846f69f