### PR TITLE
feat: name threads using azure

### DIFF
--- a/src/app/api/thread-name/route.ts
+++ b/src/app/api/thread-name/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { azure } from "@ai-sdk/azure";
+import { generateText } from "ai";
+
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+export async function POST(request: Request) {
+  const { messages } = await request.json();
+
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return NextResponse.json(
+      { error: "No messages provided" },
+      { status: 400 },
+    );
+  }
+
+  const model = azure(process.env.AZURE_DEPLOYMENT_NAME || "gpt-4o");
+  const prompt = `Create a short descriptive title of five words or fewer for a conversation based on the following messages:\n${messages.join("\n")}`;
+
+  try {
+    const { text } = await generateText({ model, prompt });
+    const title = text
+      .trim()
+      .split(/\s+/)
+      .slice(0, 5)
+      .join(" ");
+    return NextResponse.json({ title });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -6,9 +6,11 @@ import {
   ThreadPrimitive,
   useMessage,
   useComposerRuntime,
+  useThread,
+  useAssistantRuntime,
   type TextContentPart,
 } from "@assistant-ui/react";
-import { useMemo, useRef, useState, type FC } from "react";
+import { useEffect, useMemo, useRef, useState, type FC } from "react";
 import Image from "next/image";
 import {
   ArrowDownIcon,
@@ -38,6 +40,7 @@ export const Thread: FC = () => {
         ["--thread-max-width" as string]: "62rem",
       }}
     >
+      <ThreadTitleGenerator />
       <ThreadPrimitive.Viewport className="flex h-full flex-col items-center overflow-y-scroll scroll-smooth bg-inherit px-4 pt-[60px]">
         <ThreadWelcome />
 
@@ -60,6 +63,55 @@ export const Thread: FC = () => {
       </ThreadPrimitive.Viewport>
     </ThreadPrimitive.Root>
   );
+};
+
+const ThreadTitleGenerator: FC = () => {
+  const runtime = useAssistantRuntime();
+  const messages = useThread((t) => t.messages);
+  const threadId = useThread((t) => t.threadId);
+  const generatedRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    if (!runtime) return;
+    const threadItem = runtime.threads.mainItem;
+    const title = threadItem.getState().title;
+    if (
+      messages.length > 0 &&
+      !title &&
+      !generatedRef.current.has(threadId)
+    ) {
+      generatedRef.current.add(threadId);
+      const userMessages = messages
+        .filter((m) => m.role === "user")
+        .map((m) =>
+          m.content
+            .filter((c) => c.type === "text")
+            .map((c) => (c as TextContentPart).text)
+            .join(" ")
+        );
+      fetch("/api/thread-name", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: userMessages }),
+      })
+        .then((res) => res.json())
+        .then((data) => {
+          if (data.title) {
+            const title = data.title
+              .trim()
+              .split(/\s+/)
+              .slice(0, 5)
+              .join(" ");
+            threadItem.rename(title);
+          }
+        })
+        .catch((err) =>
+          console.error("Failed to generate thread title", err),
+        );
+    }
+  }, [runtime, messages, threadId]);
+
+  return null;
 };
 
 const ThreadScrollToBottom: FC = () => {


### PR DESCRIPTION
## Summary
- name threads via Azure OpenAI API after thread creation
- expose `/api/thread-name` endpoint to generate concise thread titles
- limit generated titles to five words or fewer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1b103e730833090337e234846f69f