### PR TITLE
Fix thread panel layout and adjust toggle icon corners

### DIFF
--- a/src/app/assistant.tsx
+++ b/src/app/assistant.tsx
@@ -5,7 +5,7 @@ import { MastraRuntimeProvider } from "@/app/MastraRuntimeProvider";
 import { Thread } from "@/components/assistant-ui/thread";
 import { ThreadList } from "@/components/assistant-ui/thread-list";
 import { cn } from "@/lib/utils";
-import { PanelLeftCloseIcon, PanelLeftOpenIcon } from "lucide-react";
+import { PanelLeftCloseIcon, PanelLeftOpenIcon } from "@/components/panel-icons";
 
 export const Assistant = () => {
   const [open, setOpen] = useState(false);
@@ -15,7 +15,7 @@ export const Assistant = () => {
       <div className="flex h-full">
         <aside
           className={cn(
-            "border-r bg-muted transition-all duration-300 overflow-hidden h-[calc(100dvh-5rem)]",
+            "border-r bg-muted transition-all duration-300 overflow-hidden h-[calc(100dvh-4.5rem)]",
             open ? "mt-18 w-64 p-4" : "w-0 p-0"
           )}
         >
@@ -24,7 +24,7 @@ export const Assistant = () => {
         <div className="relative flex-1">
           <button
             onClick={() => setOpen((o) => !o)}
-            className="absolute left-0 top-18 z-52 rounded-md border p-1 bg-background hover:bg-muted"
+            className="absolute left-0 top-18 z-52 rounded-r-md rounded-l-none border p-1 bg-background hover:bg-muted"
             aria-label={open ? "Close thread list" : "Open thread list"}
           >
             {open ? (

--- a/src/components/panel-icons.tsx
+++ b/src/components/panel-icons.tsx
@@ -1,0 +1,35 @@
+import type { LucideProps } from "lucide-react";
+
+export const PanelLeftCloseIcon = (props: LucideProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M3 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H3V3Z" />
+    <path d="M9 3v18" />
+    <path d="m16 15-3-3 3-3" />
+  </svg>
+);
+
+export const PanelLeftOpenIcon = (props: LucideProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M3 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H3V3Z" />
+    <path d="M9 3v18" />
+    <path d="m14 9 3 3-3 3" />
+  </svg>
+);


### PR DESCRIPTION
## Summary
- make thread list panel flush with the bottom of the viewport
- square off left corners of thread list toggle button and icons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1bd9bc0b4833080eac08db9cef88f