### PR TITLE
refactor: polish site layout and navigation

### DIFF
--- a/src/app/assistant.tsx
+++ b/src/app/assistant.tsx
@@ -15,8 +15,8 @@ export const Assistant = () => {
       <div className="flex h-full">
         <aside
           className={cn(
-            "border-r bg-muted transition-all duration-300 overflow-hidden h-[calc(100dvh-4.5rem)]",
-            open ? "mt-18 w-64 p-4" : "w-0 p-0"
+            "border-r bg-muted transition-all duration-300 overflow-hidden h-full",
+            open ? "w-64 p-4" : "w-0 p-0"
           )}
         >
           {open && <ThreadList />}
@@ -24,7 +24,7 @@ export const Assistant = () => {
         <div className="relative flex-1">
           <button
             onClick={() => setOpen((o) => !o)}
-            className="absolute left-0 top-18 z-52 rounded-r-md rounded-l-none border p-1 bg-background hover:bg-muted"
+            className="absolute left-0 top-4 z-50 rounded-r-md rounded-l-none border p-1 bg-background hover:bg-muted"
             aria-label={open ? "Close thread list" : "Open thread list"}
           >
             {open ? (

--- a/src/app/data/page.tsx
+++ b/src/app/data/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import BarChart from "@/components/bar-chart";
+import { Navbar } from "@/components/navbar";
 
 type TableData = {
   headers: string[];
@@ -81,6 +82,7 @@ export default function DataPage() {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
+      <Navbar />
       {/* Header with subtle border */}
       <header className="relative py-8 mb-8 border-b border-border">
         <div className="container mx-auto px-4 relative z-10">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -160,6 +160,6 @@
     @apply border-border outline-ring/50;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Bank-Now Assitant",
-  description: "Bank-Now Assistant for ABS Data",
+  title: "Bank-Now Assistant",
+  description: "Bank-Now assistant for exploring ABS data",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,32 +1,11 @@
 import { Assistant } from "./assistant";
-import Link from "next/link";
-import Image from "next/image";
-import { UserAvatar } from "../components/user-avatar";
+import { Navbar } from "@/components/navbar";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center bg-background text-wrap">
-      <header className="w-full py-4 px-6 mb-8 flex fixed top-0 z-50 justify-between items-center bg-gradient-to-r from-purple-900 via-fuchsia-700 to-pink-600 text-white shadow-sm">
-        <div className="flex items-center gap-2">
-          <Image
-            src="/bank-now-logo.svg"
-            alt="Bank Now logo"
-            width={40}
-            height={40}
-          />
-          <h1 className="ml-25 text-2xl font-semibold">Chat with ABS Data</h1>
-        </div>
-        <div className="flex items-center gap-4">
-          <Link
-            href="/data"
-            className="mr-25 px-4 py-2 text-sm bg-secondary hover:bg-secondary/90 text-secondary-foreground rounded-md transition-colors"
-          >
-            View Dataset
-          </Link>
-          <UserAvatar />
-        </div>
-      </header>
-      <div className="w-full h-dvh">
+    <main className="flex min-h-screen flex-col bg-background">
+      <Navbar />
+      <div className="flex flex-1">
         <Assistant />
       </div>
     </main>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { UserAvatar } from "./user-avatar";
+import { Button } from "./ui/button";
+
+export function Navbar() {
+  return (
+    <header className="sticky top-0 z-50 w-full border-b bg-card shadow-sm">
+      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4">
+        <Link href="/" className="flex items-center gap-2">
+          <Image src="/bank-now-logo.svg" alt="Bank Now logo" width={32} height={32} />
+          <span className="text-lg font-semibold text-foreground">Chat with ABS Data</span>
+        </Link>
+        <div className="flex items-center gap-4">
+          <Button asChild variant="outline" size="sm">
+            <Link href="/data">View Dataset</Link>
+          </Button>
+          <UserAvatar />
+        </div>
+      </div>
+    </header>
+  );
+}
+

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -80,16 +80,16 @@ export function UserAvatar() {
   return (
     <div className="relative">
       <div
-        className="w-8 h-8 rounded-full bg-white text-purple-700 flex items-center justify-center text-sm font-medium cursor-pointer"
+        className="w-8 h-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-medium cursor-pointer"
         onClick={() => setShowPopup((prev) => !prev)}
       >
         {initials}
       </div>
       {showPopup && (
-        <div className="absolute right-0 mt-2 bg-white text-purple-700 border border-purple-200 rounded-md shadow-md px-3 py-1 text-xs z-50">
+        <div className="absolute right-0 mt-2 bg-card text-foreground border border-border rounded-md shadow-md px-3 py-1 text-xs z-50">
           <div>{name || "Anonymous"}</div>
           <button
-            className="mt-1 text-left text-purple-700 hover:underline"
+            className="mt-1 text-left text-primary hover:underline"
             onClick={() => {
               window.location.href = "/.auth/logout";
             }}


### PR DESCRIPTION
## Summary
- add reusable navigation bar with theme-aware styling
- apply consistent font and avatar colors for a more professional UI
- clean up assistant panel layout and update metadata

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1c6e977a48330af69a7908fdf0af5