### PR TITLE
feat: add spacing before first chat message

### DIFF
--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -42,7 +42,7 @@ export const Thread: FC = () => {
       }}
     >
       <ThreadTitleGenerator />
-      <ThreadPrimitive.Viewport className="flex h-full flex-col items-center overflow-y-scroll scroll-smooth bg-inherit px-4 pt-[60px]">
+      <ThreadPrimitive.Viewport className="flex h-full flex-col items-center overflow-y-scroll scroll-smooth bg-inherit px-4 pt-[88px]">
         <ThreadWelcome />
 
         <ThreadPrimitive.Messages


### PR DESCRIPTION
## Summary
- add top padding so first chat message clears header

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a1cced3bb48330a6e6d9dd63ea2cb1