### PR TITLE
Close avatar popup and add pointer cursors

### DIFF
--- a/src/app/assistant.tsx
+++ b/src/app/assistant.tsx
@@ -24,13 +24,13 @@ export const Assistant = () => {
         <div className="relative flex-1">
           <button
             onClick={() => setOpen((o) => !o)}
-            className="absolute left-0 top-18 z-52 rounded-r-md rounded-l-none border p-1 bg-background hover:bg-muted"
+            className="absolute left-0 top-18 z-52 rounded-r-md rounded-l-none border p-1 bg-background hover:bg-muted cursor-pointer"
             aria-label={open ? "Close thread list" : "Open thread list"}
           >
             {open ? (
-              <PanelLeftCloseIcon className="h-6 w-6" />
+              <PanelLeftCloseIcon className="h-6 w-6 cursor-pointer" />
             ) : (
-              <PanelLeftOpenIcon className="h-6 w-6" />
+              <PanelLeftOpenIcon className="h-6 w-6 cursor-pointer" />
             )}
           </button>
           <Thread />

--- a/src/components/assistant-ui/thread-list.tsx
+++ b/src/components/assistant-ui/thread-list.tsx
@@ -21,7 +21,7 @@ const ThreadListNew: FC = () => {
   return (
     <ThreadListPrimitive.New asChild>
       <Button
-        className="data-[active]:bg-muted hover:bg-muted flex items-center justify-start gap-1 rounded-lg px-2.5 py-2 text-start"
+        className="data-[active]:bg-muted hover:bg-muted flex items-center justify-start gap-1 rounded-lg px-2.5 py-2 text-start cursor-pointer"
         variant="ghost"
       >
         <PlusIcon />
@@ -38,7 +38,7 @@ const ThreadListItems: FC = () => {
 const ThreadListItem: FC = () => {
   return (
     <ThreadListItemPrimitive.Root className="data-[active]:bg-muted hover:bg-muted focus-visible:bg-muted focus-visible:ring-ring flex items-center gap-2 rounded-lg transition-all focus-visible:outline-none focus-visible:ring-2">
-      <ThreadListItemPrimitive.Trigger className="flex-grow px-3 py-2 text-start">
+      <ThreadListItemPrimitive.Trigger className="flex-grow px-3 py-2 text-start cursor-pointer">
         <ThreadListItemTitle />
       </ThreadListItemPrimitive.Trigger>
       <ThreadListItemArchive />
@@ -58,7 +58,7 @@ const ThreadListItemArchive: FC = () => {
   return (
     <ThreadListItemPrimitive.Archive asChild>
       <TooltipIconButton
-        className="hover:text-primary text-foreground ml-auto mr-3 size-4 p-0"
+        className="hover:text-primary text-foreground ml-auto mr-3 size-4 p-0 cursor-pointer"
         variant="ghost"
         tooltip="Archive thread"
       >

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -157,7 +157,7 @@ const ThreadWelcomeSuggestions: FC = () => {
           {row.map((question) => (
             <ThreadPrimitive.Suggestion
               key={question}
-              className="hover:bg-muted/80 flex max-w-sm grow basis-0 flex-col items-center justify-center rounded-lg border p-3 transition-colors ease-in"
+              className="hover:bg-muted/80 flex max-w-sm grow basis-0 flex-col items-center justify-center rounded-lg border p-3 transition-colors ease-in cursor-pointer"
               prompt={question}
               method="replace"
               autoSend
@@ -249,7 +249,7 @@ const ComposerAction: FC = () => {
         variant="outline"
         onClick={listening ? stopListening : startListening}
         className={cn(
-          "my-2.5 size-8 p-2 transition-opacity ease-in",
+          "my-2.5 size-8 p-2 transition-opacity ease-in cursor-pointer",
           listening && "text-red-500"
         )}
       >
@@ -261,7 +261,7 @@ const ComposerAction: FC = () => {
           <TooltipIconButton
             tooltip="Send"
             variant="default"
-            className="my-2.5 size-8 p-2 transition-opacity ease-in"
+            className="my-2.5 size-8 p-2 transition-opacity ease-in cursor-pointer"
           >
             <SendHorizontalIcon />
           </TooltipIconButton>

--- a/src/components/assistant-ui/tooltip-icon-button.tsx
+++ b/src/components/assistant-ui/tooltip-icon-button.tsx
@@ -28,7 +28,7 @@ export const TooltipIconButton = forwardRef<
             variant="ghost"
             size="icon"
             {...rest}
-            className={cn("size-6 p-1", className)}
+            className={cn("cursor-pointer size-6 p-1", className)}
             ref={ref}
           >
             {children}

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface UserInfo {
   initials: string;
@@ -75,11 +75,22 @@ export function useUserInitials() {
 export function UserAvatar() {
   const { initials, name, checked } = useUserInitials();
   const [showPopup, setShowPopup] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setShowPopup(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
 
   if (!checked) return null;
 
   return (
-    <div className="relative">
+    <div className="relative" ref={containerRef}>
       <div
         className="w-8 h-8 rounded-full bg-white text-purple-700 flex items-center justify-center text-sm font-medium cursor-pointer"
         onClick={() => setShowPopup((prev) => !prev)}
@@ -90,7 +101,7 @@ export function UserAvatar() {
         <div className="absolute right-0 mt-2 bg-white text-purple-700 border border-purple-200 rounded-md shadow-md px-3 py-1 text-xs z-50">
           <div>{name || "Anonymous"}</div>
           <button
-            className="mt-1 text-left text-purple-700 hover:underline"
+            className="mt-1 text-left text-purple-700 hover:underline cursor-pointer"
             onClick={() => {
               window.location.href = "/.auth/logout";
             }}


### PR DESCRIPTION
## Summary
- Hide avatar popup when clicking outside and make logout action use pointer cursor
- Show pointer cursor on suggestions, send/mic buttons, panel toggle, and thread list actions
- Ensure icon buttons use pointer cursor by default

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a208f00c788330b2226c06483d2b53