### PR TITLE
Include fallback schema in runtime Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/src/mastra/agents/fallback-schema.sql ./src/mastra/agents/fallback-schema.sql
 
 EXPOSE 8080
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- copy `fallback-schema.sql` into production container so SQL agent can load default schema at runtime

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a20e8797148330b5c5ef8664b96ed3